### PR TITLE
Default to :info if the alert type isn't found

### DIFF
--- a/lib/bootstrap_flash_messages.rb
+++ b/lib/bootstrap_flash_messages.rb
@@ -2,10 +2,10 @@ require 'bootstrap_flash_messages/helpers'
 require 'bootstrap_flash_messages/flash_messages'
 
 module BootstrapFlashMessages
-  @alert_class_mapping = { :notice => :success, :success => :success, :info => :info, :warning => :warning, :error => :danger }
+  ALERT_CLASS_MAPPING = Hash.new(:info).merge(:notice => :success, :success => :success, :warning => :warning, :error => :danger).freeze
   
   def self.alert_class_mapping(key)
-    @alert_class_mapping[key.to_sym]
+    ALERT_CLASS_MAPPING[key.to_sym]
   end
   
   def self.initialize


### PR DESCRIPTION
If any flash messages are created with an alert type that doesn't match the current set of mappings, the resulting CSS class is "alert alert-".  This changes the behavior to default to "info" if a mapping isn't found, resulting in a class of "alert alert-info".

For reference, the specific scenario in which I hit this was in conjunction with the popular Devise gem, whereby invalid login credentials produces a flash message with key "alert".

In addition, I turned this into a class level constant and froze the hash to prevent changes.